### PR TITLE
Add NFT trophy printer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,4 +117,5 @@ dist
 .yarn/install-state.gz
 .pnp.*
 
-./test-ledger
+test-ledger
+.DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -142,6 +142,25 @@
         "KAFKA_TOPIC": "json.solana.blocks",
         "ACCOUNTS": "B97SZXJBRUBHTZiaKB4PwUwzx4N8vkqWV6beAdhiMqqg,BFrD2YQKd8Fz4eeQrUsM8GEFw8UKR4oLWq4xHL6WJNtG"
       }
+    }, {
+      "type": "pwa-node",
+      "request": "launch",
+      "name": "Trophy Process",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "${workspaceFolder}/src/trophies/index.ts",
+      "preLaunchTask": "tsc: build - tsconfig.json",
+      "outFiles": [
+        "${workspaceFolder}/dist/lib/**/*.js"
+      ],
+      "env": {
+        "KAFKA_BOOTSTRAP_SERVERS": "localhost:29092",
+        "KAFKA_INPUT_TOPIC": "json.solana.trophies",
+        "KAFKA_OFFSET_RESET": "earliest",
+        "KAFKA_GROUP_ID": "trophies4",
+        "SERVICE_ACCOUNT": "[]"
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -89,3 +89,12 @@ You can use kowl at localhost:8080 to see what's going into the topics.
 If you'd like to start the leaderboard, there are vscode launch configs for those as well.
 
 The API is a separate repo, `wumbo-api`
+
+
+# Trophies
+
+To test, you can run 
+
+```
+jq -rc . tests/resources/trophy.json | kafka-console-producer.sh --topic json.solana.trophies --bootstrap-server localhost:29092
+```

--- a/package.json
+++ b/package.json
@@ -11,23 +11,26 @@
   "devDependencies": {
     "@types/mocha": "^9.0.0",
     "@types/redis": "^2.8.31",
-    "ts-node": "^10.1.0",
-    "typescript": "^4.3.5",
+    "chai": "^4.3.4",
+    "chai-as-promised": "^7.1.1",
     "mocha": "^8.1.0",
     "ts-mocha": "^8.0.0",
-    "chai": "^4.3.4",
-    "chai-as-promised": "^7.1.1"
+    "ts-node": "^10.1.0",
+    "typescript": "^4.3.5"
   },
   "dependencies": {
+    "@project-serum/anchor": "^0.11.1",
+    "@project-serum/common": "^0.0.1-beta.3",
     "@solana/web3.js": "^1.22.0",
+    "@types/bs58": "^4.0.1",
     "@types/uuid": "^8.3.1",
     "@wum.bo/spl-token-bonding": "^1.0.0",
     "@wum.bo/spl-wumbo": "^1.0.0",
     "aws-sdk": "^2.961.0",
     "borsh": "^0.4.0",
+    "bs58": "^4.0.1",
     "kafkajs": "^1.15.0",
     "redis": "^3.1.2",
-    "uuid": "^8.3.2",
-    "@project-serum/anchor": "^0.11.1"
+    "uuid": "^8.3.2"
   }
 }

--- a/src/trophies/borsh.ts
+++ b/src/trophies/borsh.ts
@@ -1,0 +1,34 @@
+import { PublicKey } from '@solana/web3.js';
+import { BinaryReader, BinaryWriter } from 'borsh';
+import base58 from 'bs58';
+
+type StringPublicKey = string;
+
+export const extendBorsh = () => {
+  (BinaryReader.prototype as any).readPubkey = function () {
+    const reader = this as unknown as BinaryReader;
+    const array = reader.readFixedArray(32);
+    return new PublicKey(array);
+  };
+
+  (BinaryWriter.prototype as any).writePubkey = function (value: PublicKey) {
+    const writer = this as unknown as BinaryWriter;
+    writer.writeFixedArray(value.toBuffer());
+  };
+
+  (BinaryReader.prototype as any).readPubkeyAsString = function () {
+    const reader = this as unknown as BinaryReader;
+    const array = reader.readFixedArray(32);
+    return base58.encode(array) as StringPublicKey;
+  };
+
+  (BinaryWriter.prototype as any).writePubkeyAsString = function (
+    value: StringPublicKey,
+  ) {
+    const writer = this as unknown as BinaryWriter;
+    writer.writeFixedArray(base58.decode(value));
+  };
+};
+
+extendBorsh();
+

--- a/src/trophies/index.ts
+++ b/src/trophies/index.ts
@@ -1,0 +1,435 @@
+import { kafka } from "../setup/kafka";
+import { connection } from "../setup/solana";
+import { Keypair, PublicKey, sendAndConfirmTransaction, SystemInstruction, SystemProgram, SYSVAR_RENT_PUBKEY, Transaction, TransactionInstruction } from "@solana/web3.js";
+import BN from "bn.js";
+import { ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID, Token, MintLayout } from "@solana/spl-token";
+import { deserializeUnchecked } from 'borsh';
+import "./borsh";
+
+const { KAFKA_GROUP_ID, KAFKA_INPUT_TOPIC, SERVICE_ACCOUNT } = process.env
+
+const serviceAccount = Keypair.fromSecretKey( new Uint8Array(JSON.parse(SERVICE_ACCOUNT!)));
+
+const METADATA_PREFIX = 'metadata';
+const EDITION = 'edition';
+const METADATA_PROGRAM_ID = new PublicKey("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
+
+export async function getMetadata(
+  tokenMint: PublicKey,
+): Promise<PublicKey> {
+  return (
+    await PublicKey.findProgramAddress(
+      [
+        Buffer.from(METADATA_PREFIX),
+        METADATA_PROGRAM_ID.toBuffer(),
+        tokenMint.toBuffer(),
+      ],
+      METADATA_PROGRAM_ID
+    )
+  )[0];
+}
+
+async function getEdition(
+  tokenMint: PublicKey,
+): Promise<PublicKey> {
+  return (
+    await PublicKey.findProgramAddress(
+      [
+        Buffer.from(METADATA_PREFIX),
+        METADATA_PROGRAM_ID.toBuffer(),
+        tokenMint.toBuffer(),
+        Buffer.from(EDITION),
+      ],
+      METADATA_PROGRAM_ID,
+    )
+  )[0];
+}
+
+async function getEditionMarkPda(
+  mint: PublicKey,
+  edition: BN,
+): Promise<PublicKey> {
+  const editionNumber = Math.floor(edition.toNumber() / 248);
+
+  return (
+    await PublicKey.findProgramAddress(
+      [
+        Buffer.from(METADATA_PREFIX),
+        METADATA_PROGRAM_ID.toBuffer(),
+        mint.toBuffer(),
+        Buffer.from(EDITION),
+        Buffer.from(editionNumber.toString()),
+      ],
+      METADATA_PROGRAM_ID,
+    )
+  )[0];
+}
+
+enum MetadataKey {
+  Uninitialized = 0,
+  MetadataV1 = 4,
+  EditionV1 = 1,
+  MasterEditionV1 = 2,
+  MasterEditionV2 = 6,
+  EditionMarker = 7,
+}
+
+class Creator {
+  address: String;
+  verified: boolean;
+  share: number;
+
+  constructor(args: {
+    address: String;
+    verified: boolean;
+    share: number;
+  }) {
+    this.address = args.address;
+    this.verified = args.verified;
+    this.share = args.share;
+  }
+}
+
+class Data {
+  name: string;
+  symbol: string;
+  uri: string;
+  sellerFeeBasisPoints: number;
+  creators: Creator[] | null;
+  constructor(args: {
+    name: string;
+    symbol: string;
+    uri: string;
+    sellerFeeBasisPoints: number;
+    creators: Creator[] | null;
+  }) {
+    this.name = args.name;
+    this.symbol = args.symbol;
+    this.uri = args.uri;
+    this.sellerFeeBasisPoints = args.sellerFeeBasisPoints;
+    this.creators = args.creators;
+  }
+}
+
+class Metadata {
+  key: MetadataKey;
+  updateAuthority: String;
+  mint: String;
+  data: Data;
+  primarySaleHappened: boolean;
+  isMutable: boolean;
+  editionNonce: number | null;
+
+  // set lazy
+  masterEdition?: String;
+  edition?: String;
+
+  constructor(args: {
+    updateAuthority: String;
+    mint: String;
+    data: Data;
+    primarySaleHappened: boolean;
+    isMutable: boolean;
+    editionNonce: number | null;
+  }) {
+    this.key = MetadataKey.MetadataV1;
+    this.updateAuthority = args.updateAuthority;
+    this.mint = args.mint;
+    this.data = args.data;
+    this.primarySaleHappened = args.primarySaleHappened;
+    this.isMutable = args.isMutable;
+    this.editionNonce = args.editionNonce;
+  }
+
+  public async init() {
+    const edition = await getEdition(new PublicKey(this.mint));
+    this.edition = edition.toBase58();
+    this.masterEdition = edition.toBase58();
+  }
+}
+
+const METADATA_SCHEMA = new Map<any, any>([
+  [
+    Metadata,
+    {
+      kind: 'struct',
+      fields: [
+        ['key', 'u8'],
+        ['updateAuthority', 'pubkeyAsString'],
+        ['mint', 'pubkeyAsString'],
+        ['data', Data],
+        ['primarySaleHappened', 'u8'], // bool
+        ['isMutable', 'u8'], // bool
+      ],
+    },
+  ],
+  [
+    Data,
+    {
+      kind: 'struct',
+      fields: [
+        ['name', 'string'],
+        ['symbol', 'string'],
+        ['uri', 'string'],
+        ['sellerFeeBasisPoints', 'u16'],
+        ['creators', { kind: 'option', type: [Creator] }],
+      ],
+    },
+  ],
+  [
+    Creator,
+    {
+      kind: 'struct',
+      fields: [
+        ['address', 'pubkeyAsString'],
+        ['verified', 'u8'],
+        ['share', 'u8'],
+      ],
+    },
+  ],
+]);
+
+
+const METADATA_REPLACE = new RegExp('\u0000', 'g');
+const decodeMetadata = (buffer: Buffer): Metadata => {
+  const metadata = deserializeUnchecked(
+    METADATA_SCHEMA,
+    Metadata,
+    buffer,
+  ) as Metadata;
+  metadata.data.name = metadata.data.name.replace(METADATA_REPLACE, '');
+  metadata.data.uri = metadata.data.uri.replace(METADATA_REPLACE, '');
+  metadata.data.symbol = metadata.data.symbol.replace(METADATA_REPLACE, '');
+  return metadata;
+};
+
+async function mintNewEditionFromMasterEditionViaTokenInstruction(
+  newMint: PublicKey,
+  tokenMint: PublicKey,
+  newMintAuthority: PublicKey,
+  newUpdateAuthority: PublicKey,
+  tokenOwner: PublicKey,
+  tokenAccount: PublicKey,
+  payer: PublicKey,
+  edition: BN,
+): Promise<TransactionInstruction> {
+  const metadataProgramId = METADATA_PROGRAM_ID;
+
+  const newMetadataKey = await getMetadata(newMint);
+  const masterMetadataKey = await getMetadata(tokenMint);
+  const newEdition = await getEdition(newMint);
+  const masterEdition = await getEdition(tokenMint);
+  const editionMarkPda = await getEditionMarkPda(tokenMint, edition);
+
+  const data = Buffer.from([11, ...edition.toArray('le', 8)]);
+  console.log(masterMetadataKey.toBase58());
+
+  const keys = [
+    {
+      pubkey: newMetadataKey,
+      isSigner: false,
+      isWritable: true,
+    },
+    {
+      pubkey: newEdition,
+      isSigner: false,
+      isWritable: true,
+    },
+    {
+      pubkey: masterEdition,
+      isSigner: false,
+      isWritable: true,
+    },
+    {
+      pubkey: newMint,
+      isSigner: false,
+      isWritable: true,
+    },
+    {
+      pubkey: editionMarkPda,
+      isSigner: false,
+      isWritable: true,
+    },
+    {
+      pubkey: newMintAuthority,
+      isSigner: true,
+      isWritable: false,
+    },
+    {
+      pubkey: payer,
+      isSigner: true,
+      isWritable: false,
+    },
+    {
+      pubkey: tokenOwner,
+      isSigner: true,
+      isWritable: false,
+    },
+    {
+      pubkey: tokenAccount,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: newUpdateAuthority,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: masterMetadataKey,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: TOKEN_PROGRAM_ID,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: SystemProgram.programId,
+      isSigner: false,
+      isWritable: false,
+    },
+    {
+      pubkey: SYSVAR_RENT_PUBKEY,
+      isSigner: false,
+      isWritable: false,
+    },
+  ];
+
+  return new TransactionInstruction({
+    keys,
+    programId: metadataProgramId,
+    data,
+  });
+}
+
+let currentEditions = new Map<string, number>();
+async function getOrFindNextEdition(mint: PublicKey) {
+  if (currentEditions.has(mint.toBase58())) {
+    const next = currentEditions.get(mint.toBase58())! + 1
+    currentEditions.set(mint.toBase58(), next)
+    return next;
+  }
+  
+  let currentEdition = 0;
+  while (await connection.getAccountInfo(await getEditionMarkPda(mint, new BN(currentEdition)))) {
+    currentEdition += 1;
+  }
+  currentEditions.set(mint.toBase58(), currentEdition + 1);
+
+  return currentEdition + 1;
+}
+
+const metaToTokenCache = new Map<string, PublicKey>();
+async function getMintFromMeta(meta: PublicKey): Promise<PublicKey> {
+  if (metaToTokenCache.has(meta.toBase58())) {
+    return metaToTokenCache.get(meta.toBase58())!;
+  }
+  const acct = await connection.getAccountInfo(meta);
+  const trophyMasterEditionMetaAcct = await decodeMetadata(acct!.data);
+  const ret = new PublicKey(trophyMasterEditionMetaAcct.mint);
+  metaToTokenCache.set(meta.toBase58(), ret);
+
+  return ret;
+}
+
+async function run() {
+  const consumer = kafka.consumer({
+    groupId: KAFKA_GROUP_ID!
+  });
+
+  await consumer.connect();
+  await consumer.subscribe({
+    topic: KAFKA_INPUT_TOPIC!,
+    fromBeginning: process.env["KAFKA_OFFSET_RESET"] === "earliest"
+  });
+
+  return new Promise((resolve, reject) => {
+    consumer.run({
+      eachBatch: async (args) => {
+        try {
+          const messages = args.batch.messages.map(m => JSON.parse(m.value!.toString()));
+          await Promise.all(
+            messages.map(async message => {
+              const destination = new PublicKey(message.destination)
+              const trophyMasterEditionMeta = new PublicKey(message.trophyMasterEditionMeta);
+              const masterEditionMint = await getMintFromMeta(trophyMasterEditionMeta);
+              const txn = new Transaction()
+              const mint = Keypair.generate();
+              const ata = await Token.getAssociatedTokenAddress(
+                ASSOCIATED_TOKEN_PROGRAM_ID,
+                TOKEN_PROGRAM_ID,
+                mint.publicKey,
+                destination
+              );
+              const masterEditionAta = await Token.getAssociatedTokenAddress(
+                ASSOCIATED_TOKEN_PROGRAM_ID,
+                TOKEN_PROGRAM_ID,
+                masterEditionMint,
+                serviceAccount.publicKey
+              );
+              const metadata = await getMetadata(mint.publicKey);
+              console.log(`Sending trophy...`);
+              
+              txn.instructions = [
+                SystemProgram.createAccount({
+                  fromPubkey: serviceAccount.publicKey,
+                  newAccountPubkey: mint.publicKey,
+                  lamports: await Token.getMinBalanceRentForExemptMint(connection),
+                  space: MintLayout.span,
+                  programId: TOKEN_PROGRAM_ID
+                }),
+                Token.createInitMintInstruction(
+                  TOKEN_PROGRAM_ID,
+                  mint.publicKey,
+                  0,
+                  serviceAccount.publicKey,
+                  null
+                ),
+                Token.createAssociatedTokenAccountInstruction(
+                  ASSOCIATED_TOKEN_PROGRAM_ID,
+                  TOKEN_PROGRAM_ID,
+                  mint.publicKey,
+                  ata,
+                  destination,
+                  serviceAccount.publicKey
+                ),
+                Token.createMintToInstruction(
+                  TOKEN_PROGRAM_ID,
+                  mint.publicKey,
+                  ata,
+                  serviceAccount.publicKey,
+                  [],
+                  1
+                ),
+                await mintNewEditionFromMasterEditionViaTokenInstruction(
+                  mint.publicKey,
+                  masterEditionMint,
+                  serviceAccount.publicKey,
+                  serviceAccount.publicKey,
+                  serviceAccount.publicKey,
+                  masterEditionAta,
+                  serviceAccount.publicKey,
+                  new BN(await getOrFindNextEdition(masterEditionMint))
+                )
+              ]
+              const txid = await sendAndConfirmTransaction(connection, txn, [serviceAccount, mint])
+
+              console.log(`Sent trophy ${message.trophyShortName}, trophy mint ${masterEditionMint.toBase58()}, trophy meta ${message.trophyMasterEdition} to ${destination.toBase58()} (${ata.toBase58()}) with mint ${mint.publicKey} and metadata ${metadata}, txid ${txid}`);
+            })
+          )
+        } catch(e) {
+          reject(e)
+          throw e;
+        }
+      }
+    })
+  })
+}
+
+run().catch(e => {
+  console.error(e);
+  console.error(e.stack);
+  process.exit(1);
+})

--- a/tests/resources/trophy.json
+++ b/tests/resources/trophy.json
@@ -1,0 +1,5 @@
+{
+  "trophyShortName": "wumbo",
+  "trophyMasterEditionMeta": "E8FV6MyzzRogudCsQoNcHnmzDMNzqiNEe9YvFcZUcMYz",
+  "destination": "2LHvWCsg14JZJYqJBr4E6EpCaLYg9QBzWPmHkDkvHtYc"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,6 +104,26 @@
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
 
+"@project-serum/common@^0.0.1-beta.3":
+  version "0.0.1-beta.3"
+  resolved "https://registry.yarnpkg.com/@project-serum/common/-/common-0.0.1-beta.3.tgz#53586eaff9d9fd7e8938b1e12080c935b8b6ad07"
+  integrity sha512-gnQE/eUydTtto5okCgLWj1M97R9RRPJqnhKklikYI7jP/pnNhDmngSXC/dmfzED2GXSJEIKNIlxVw1k+E2Aw3w==
+  dependencies:
+    "@project-serum/serum" "^0.13.21"
+    bn.js "^5.1.2"
+    superstruct "0.8.3"
+
+"@project-serum/serum@^0.13.21":
+  version "0.13.58"
+  resolved "https://registry.yarnpkg.com/@project-serum/serum/-/serum-0.13.58.tgz#0f4aaa98f28c1220f8131052cd33b36d43430266"
+  integrity sha512-g8PNsFiJ3qTGu5B1qHdGIfmXovka3DpC9cMhyYzdKKX3WqdpzHrwKYO/ZuqH+JBp+dGfjYTxRLQ3dNTxYWohHA==
+  dependencies:
+    "@project-serum/anchor" "^0.11.1"
+    "@solana/spl-token" "^0.1.6"
+    "@solana/web3.js" "^1.21.0"
+    bn.js "^5.1.2"
+    buffer-layout "^1.2.0"
+
 "@project-serum/sol-wallet-adapter@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@project-serum/sol-wallet-adapter/-/sol-wallet-adapter-0.2.5.tgz#d949a8cc4d2f74e31e4f0205989703977689c76b"
@@ -138,6 +158,18 @@
   dependencies:
     "@babel/runtime" "^7.10.5"
     "@solana/web3.js" "^1.12.0"
+    bn.js "^5.1.0"
+    buffer "6.0.3"
+    buffer-layout "^1.2.0"
+    dotenv "10.0.0"
+
+"@solana/spl-token@^0.1.6":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.1.8.tgz#f06e746341ef8d04165e21fc7f555492a2a0faa6"
+  integrity sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==
+  dependencies:
+    "@babel/runtime" "^7.10.5"
+    "@solana/web3.js" "^1.21.0"
     bn.js "^5.1.0"
     buffer "6.0.3"
     buffer-layout "^1.2.0"
@@ -261,6 +293,26 @@
     superstruct "^0.14.2"
     tweetnacl "^1.0.0"
 
+"@solana/web3.js@^1.21.0":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.24.2.tgz#ff98c635effac3c49bfe757bf182792feb973fc6"
+  integrity sha512-zpW/QumeNBg8BfXB4LWFjrRlutWhwCKOaffP0+V0SF47pJsH/eShTOCl0I3Dibv6KeVgJzauNyKug6wnZVtXVQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@solana/buffer-layout" "^3.0.0"
+    bn.js "^5.0.0"
+    borsh "^0.4.0"
+    bs58 "^4.0.1"
+    buffer "6.0.1"
+    crypto-hash "^1.2.2"
+    jayson "^3.4.4"
+    js-sha3 "^0.8.0"
+    node-fetch "^2.6.1"
+    rpc-websockets "^7.4.2"
+    secp256k1 "^4.0.2"
+    superstruct "^0.14.2"
+    tweetnacl "^1.0.0"
+
 "@toruslabs/eccrypto@^1.1.7":
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/@toruslabs/eccrypto/-/eccrypto-1.1.7.tgz#962954d6416f56ca2ba9bb9948cd08bd3b8cd0c4"
@@ -350,6 +402,13 @@
   integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
   dependencies:
     "@types/node" "*"
+
+"@types/bs58@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/bs58/-/bs58-4.0.1.tgz#3d51222aab067786d3bc3740a84a7f5a0effaa37"
+  integrity sha512-yfAgiWgVLjFCmRv8zAcOIHywYATEwiTVccTLnRp6UxTNavT55M9d/uhK3T03St/+8/z/wW+CRjGKUNmEqoHHCA==
+  dependencies:
+    base-x "^3.0.6"
 
 "@types/connect@^3.4.33":
   version "3.4.35"
@@ -704,7 +763,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base-x@^3.0.2:
+base-x@^3.0.2, base-x@^3.0.6:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.8.tgz#1e1106c2537f0162e8b52474a557ebb09000018d"
   integrity sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==
@@ -3719,6 +3778,14 @@ strip-json-comments@3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+superstruct@0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.8.3.tgz#fb4d8901aca3bf9f79afab1bbab7a7f335cc4ef2"
+  integrity sha512-LbtbFpktW1FcwxVIJlxdk7bCyBq/GzOx2FSFLRLTUhWIA1gHkYPIl3aXRG5mBdGZtnPNT6t+4eEcLDCMOuBHww==
+  dependencies:
+    kind-of "^6.0.2"
+    tiny-invariant "^1.0.6"
+
 superstruct@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.14.2.tgz#0dbcdf3d83676588828f1cf5ed35cda02f59025b"
@@ -3764,6 +3831,11 @@ thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
+
+tiny-invariant@^1.0.6:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
 
 tiny-secp256k1@^1.1.3:
   version "1.1.6"


### PR DESCRIPTION
If you publish something like what is in test/resources/trophies.json it will mint that trophy.

You need to run a local metaplex and create the nft for the trophy, then get the metadata address from the url of the NFT. 

We will create a bunch of these, then create kSQL queries publishing to json.solana.trophies the destinations that earn the NFT. 